### PR TITLE
chore: remove fabricated metrics from projects

### DIFF
--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -89,24 +89,6 @@ export default function ProjectCard({ project, featured = false }: ProjectCardPr
               ))}
             </ul>
           </div>
-
-          {project.metrics && (
-            <div>
-              <h4 className="text-sm font-medium mb-2">Metrics</h4>
-              <div className="grid grid-cols-2 gap-2">
-                {project.metrics.map((metric, index) => (
-                  <div key={index} className="text-center p-2 bg-muted rounded">
-                    <div className="text-lg font-bold text-primary">
-                      {metric.value}
-                    </div>
-                    <div className="text-xs text-muted-foreground">
-                      {metric.label}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
         </div>
       </CardContent>
 

--- a/contents/index.ts
+++ b/contents/index.ts
@@ -65,10 +65,6 @@ export const PROJECTS: Project[] = [
       'SEO optimization and performance enhancements',
       'Responsive design from scratch'
     ],
-    metrics: [
-      { label: 'Performance Score', value: '95+' },
-      { label: 'SEO Score', value: '100' }
-    ],
     period: '2024'
   },
   {
@@ -122,10 +118,6 @@ export const PROJECTS: Project[] = [
       'Dynamic table of contents for blog pages',
       'Cross-browser compatibility',
       'Pixel-perfect design implementation'
-    ],
-    metrics: [
-      { label: 'Animation Performance', value: '60fps' },
-      { label: 'Lighthouse Score', value: '95+' }
     ],
     period: '2023'
   },


### PR DESCRIPTION
## Summary
- Removed fabricated performance scores, SEO scores, Lighthouse scores, and animation performance metrics from project data
- Removed metrics display section from ProjectCard component since no real metrics data is available

## Test plan
- [x] Verify projects display correctly without metrics section
- [x] Check that all project cards render properly
- [x] Confirm no broken layouts or missing data